### PR TITLE
Classes

### DIFF
--- a/Classes.agda
+++ b/Classes.agda
@@ -75,13 +75,13 @@ instance
 
 record MonoidalP (_→k_ : Set → Set → Set) : Set where
   field
-    _×c_ : (A →k C) → (B →k D) → ((A × B) →k (C × D))
+    _⊗_ : (A →k C) → (B →k D) → ((A × B) →k (C × D))
 open MonoidalP ⦃ … ⦄ public
 
 instance
   →-MonoidalP : MonoidalP (λ (A B : Set) → A → B)
   →-MonoidalP = record {
-    _×c_ = λ { f g (a , b) → f a , g b } }
+    _⊗_ = λ { f g (a , b) → f a , g b } }
 
 record Num (A : Set) : Set where
   field

--- a/Classes.agda
+++ b/Classes.agda
@@ -1,0 +1,39 @@
+{-# OPTIONS --type-in-type --rewriting #-}
+
+-- {-# OPTIONS --injective-type-constructors #-}
+
+module Classes where
+
+open import Data.Product renaming (swap to pswap)
+open import Data.Unit
+open import Function
+open import Data.Nat renaming (_+_ to _+ℕ_; _*_ to _*ℕ_)
+
+open import Relation.Binary.PropositionalEquality as PE hiding ([_])
+open PE.≡-Reasoning
+open import Agda.Builtin.Equality.Rewrite
+
+private
+  variable
+   A B C D U V Z : Set
+   _→k_ : Set → Set → Set
+
+record Category (_→k_ : Set → Set → Set) : Set where
+  infixr 5 _∘c_
+  field
+    idc   : A →k A
+    _∘c_  : (B →k C) → (A →k B) → (A →k C)
+    .id-l  : ∀ {f : A →k B} → idc ∘c f ≡ f
+    .id-r  : ∀ {f : A →k B} → f ∘c idc ≡ f
+    .assoc : ∀ {h : C →k D} {g : B →k C} {f : A →k B}
+           → (h ∘c g) ∘c f ≡ h ∘c (g ∘c f)
+open Category ⦃ … ⦄ public
+
+instance
+  _ : Category (λ (A B : Set) → A → B)
+  _ = record {
+    idc = id ;
+    _∘c_ = _∘′_ ;
+    id-l = refl ;
+    id-r = refl ;
+    assoc = refl }

--- a/Classes.agda
+++ b/Classes.agda
@@ -6,7 +6,7 @@ module Classes where
 
 open import Data.Product renaming (swap to pswap)
 open import Data.Unit
-open import Function
+open import Function renaming (_∘_ to _∘→_; id to id→)
 open import Data.Nat renaming (_+_ to _+ℕ_; _*_ to _*ℕ_)
 
 open import Relation.Binary.PropositionalEquality as PE hiding ([_])
@@ -19,21 +19,21 @@ private
    _→k_ : Set → Set → Set
 
 record Category (_→k_ : Set → Set → Set) : Set where
-  infixr 5 _∘c_
+  infixr 5 _∘_
   field
-    idc   : A →k A
-    _∘c_  : (B →k C) → (A →k B) → (A →k C)
-    .id-l  : ∀ {f : A →k B} → idc ∘c f ≡ f
-    .id-r  : ∀ {f : A →k B} → f ∘c idc ≡ f
+    id   : A →k A
+    _∘_  : (B →k C) → (A →k B) → (A →k C)
+    .id-l  : ∀ {f : A →k B} → id ∘ f ≡ f
+    .id-r  : ∀ {f : A →k B} → f ∘ id ≡ f
     .assoc : ∀ {h : C →k D} {g : B →k C} {f : A →k B}
-           → (h ∘c g) ∘c f ≡ h ∘c (g ∘c f)
+           → (h ∘ g) ∘ f ≡ h ∘ (g ∘ f)
 open Category ⦃ … ⦄ public
 
 instance
   →-Category : Category (λ (A B : Set) → A → B)
   →-Category = record {
-    idc = id ;
-    _∘c_ = _∘′_ ;
+    id = id→ ;
+    _∘_ = _∘′_ ;
     id-l = refl ;
     id-r = refl ;
     assoc = refl }

--- a/Classes.agda
+++ b/Classes.agda
@@ -30,10 +30,68 @@ record Category (_→k_ : Set → Set → Set) : Set where
 open Category ⦃ … ⦄ public
 
 instance
-  _ : Category (λ (A B : Set) → A → B)
-  _ = record {
+  →-Category : Category (λ (A B : Set) → A → B)
+  →-Category = record {
     idc = id ;
     _∘c_ = _∘′_ ;
     id-l = refl ;
     id-r = refl ;
     assoc = refl }
+
+record Cartesian (_→k_ : Set → Set → Set) : Set where
+  field
+    exl : (A × B) →k A
+    exr : (A × B) →k B
+    dup : A →k (A × A)
+open Cartesian ⦃ … ⦄ public
+
+instance
+  →-Cartesian : Cartesian (λ (A B : Set) → A → B)
+  →-Cartesian = record {
+    exl = proj₁ ;
+    exr = proj₂ ;
+    dup = λ a → (a , a) }
+
+record AssociativeCat (_→k_ : Set → Set → Set) : Set where
+  field
+    rassoc : ((A × B) × C) →k (A × (B × C))
+    lassoc : (A × (B × C)) →k ((A × B) × C)
+open AssociativeCat ⦃ … ⦄ public
+
+instance
+  →-AssociativeCat : AssociativeCat (λ (A B : Set) → A → B)
+  →-AssociativeCat = record {
+    rassoc = λ { ((a , b) , c) → a , b , c } ;
+    lassoc = λ { (a , b , c) → (a , b) , c } }
+
+record BraidedCat (_→k_ : Set → Set → Set) : Set where
+  field
+    swap : (A × B) →k (B × A)
+open BraidedCat ⦃ … ⦄ public
+
+instance
+  →-BraidedCat : BraidedCat (λ (A B : Set) → A → B)
+  →-BraidedCat = record { swap = λ {(a , b) → b , a} }
+
+record MonoidalP (_→k_ : Set → Set → Set) : Set where
+  field
+    _×c_ : (A →k C) → (B →k D) → ((A × B) →k (C × D))
+open MonoidalP ⦃ … ⦄ public
+
+instance
+  →-MonoidalP : MonoidalP (λ (A B : Set) → A → B)
+  →-MonoidalP = record {
+    _×c_ = λ { f g (a , b) → f a , g b } }
+
+record Num (A : Set) : Set where
+  field
+    _+_ _*_ _-_ : A → A → A
+    abs signum negate : A → A
+    fromℕ : ℕ → A
+open Num ⦃ … ⦄ public
+
+record NumCat (_→k_ : Set → Set → Set) (A : Set) : Set where
+  field
+    _+c_ _*c_ _-c_ : (A × A) →k A
+    negate-c : A →k A
+open NumCat ⦃ … ⦄ public

--- a/IxList.agda
+++ b/IxList.agda
@@ -11,6 +11,8 @@ open import Relation.Binary.PropositionalEquality as PE
 open PE.≡-Reasoning
 open import Agda.Builtin.Equality.Rewrite
 
+open import Classes
+
 private
   variable
    A B C D U V : Set
@@ -68,3 +70,11 @@ evalIL-∘ ev (op ∷ f) g =
 
 -- TODO: Can we automate the evalIL-∘ proof by using the REWRITE recursively?
 
+instance
+  IxList-Category : Category (IxList _→k_)
+  IxList-Category = record {
+    idc = [] ;
+    _∘c_ = _∘il_ ;
+    id-l = refl ;
+    id-r = refl ;
+    assoc = refl }

--- a/IxList.agda
+++ b/IxList.agda
@@ -4,7 +4,7 @@
 
 module IxList where
 
-open import Function
+open import Function hiding (id; _∘_)
 
 open import Relation.Binary.PropositionalEquality as PE
        hiding (Extensionality; [_])
@@ -73,8 +73,8 @@ evalIL-∘ ev (op ∷ f) g =
 instance
   IxList-Category : Category (IxList _→k_)
   IxList-Category = record {
-    idc = [] ;
-    _∘c_ = _∘il_ ;
+    id = [] ;
+    _∘_ = _∘il_ ;
     id-l = refl ;
     id-r = refl ;
     assoc = refl }

--- a/Stack.agda
+++ b/Stack.agda
@@ -13,7 +13,7 @@ open import Relation.Binary.PropositionalEquality as PE hiding ([_])
 open PE.≡-Reasoning
 open import Agda.Builtin.Equality.Rewrite
 
-open import Classes ⦃ … ⦄
+open import Classes -- ⦃ … ⦄
 open import IxList
 
 private
@@ -57,8 +57,8 @@ _∘sf_ : StackFun B C → StackFun A B → StackFun A C
 sf g ∘sf sf f = sf (g ∘ f)
 
 instance
-  _ : Category StackFun
-  _ = record {
+  StackFun-Category : Category StackFun
+  StackFun-Category = record {
     idc = id-sf ;
     _∘c_ = _∘sf_ ;
     id-l = refl ;
@@ -74,61 +74,15 @@ stackFun-id = refl
             → stackFun (g ∘c f) ≡ stackFun g ∘c stackFun f
 stackFun-∘ = refl
 
-record MonoidalP (_→k_ : Set → Set → Set) : Set where
-  field
-    _×c_ : (A →k C) → (B →k D) → ((A × B) →k (C × D))
-open MonoidalP ⦃ … ⦄
-
 instance
-  _ : MonoidalP (λ (A B : Set) → A → B)
-  _ = record {
-    _×c_ = λ { f g (a , b) → f a , g b } }
-
-record Cartesian (_→k_ : Set → Set → Set) : Set where
-  field
-    exl : (A × B) →k A
-    exr : (A × B) →k B
-    dup : A →k (A × A)
-open Cartesian ⦃ … ⦄
-
-instance
-  _ : Cartesian (λ (A B : Set) → A → B)
-  _ = record {
-    exl = proj₁ ;
-    exr = proj₂ ;
-    dup = λ a → (a , a) }
-
-
-record AssociativeCat (_→k_ : Set → Set → Set) : Set where
-  field
-    rassoc : ((A × B) × C) →k (A × (B × C))
-    lassoc : (A × (B × C)) →k ((A × B) × C)
-open AssociativeCat ⦃ … ⦄
-
-instance
-  _ : AssociativeCat (λ (A B : Set) → A → B)
-  _ = record {
-    rassoc = λ { ((a , b) , c) → a , b , c } ;
-    lassoc = λ { (a , b , c) → (a , b) , c } }
-
-instance
-  _ : AssociativeCat StackFun
-  _ = record {
+  StackFun-AssociativeCat : AssociativeCat StackFun
+  StackFun-AssociativeCat = record {
     rassoc = stackFun rassoc ;
     lassoc = stackFun lassoc }
 
-record BraidedCat (_→k_ : Set → Set → Set) : Set where
-  field
-    swap : (A × B) →k (B × A)
-open BraidedCat ⦃ … ⦄
-
 instance
-  _ : BraidedCat (λ (A B : Set) → A → B)
-  _ = record { swap = λ {(a , b) → b , a} }
-
-instance
-  _ : BraidedCat StackFun
-  _ = record { swap = stackFun swap }
+  StackFun-BraidedCat : BraidedCat StackFun
+  StackFun-BraidedCat = record { swap = stackFun swap }
 
 firstSF : StackFun A C → StackFun (A × B) (C × B)
 firstSF (sf f) = sf (lassoc ∘ f ∘ rassoc)
@@ -147,37 +101,23 @@ f ×sf g = secondSF g ∘c firstSF f
 -- sf f ×sf sf g = sf (λ { ((a , b) , z) → f (a , proj₁ (g (b , z))) , z })
 
 instance
-  _ : MonoidalP StackFun
-  _ = record {
+  StackFun-MonoidalP : MonoidalP StackFun
+  StackFun-MonoidalP = record {
     _×c_ = _×sf_ }
 
 stackFun-× : ∀ {f : A → C} {g : B → D} → stackFun (f ×c g) ≡ stackFun f ×c stackFun g
 stackFun-× = refl
 
 instance
-  _ : Cartesian StackFun
-  _ = record {
+  StackFun-Cartesian : Cartesian StackFun
+  StackFun-Cartesian = record {
     exl = stackFun exl ;
     exr = stackFun exr ;
     dup = stackFun dup }
 
-
-record Num (A : Set) : Set where
-  field
-    _+_ _*_ _-_ : A → A → A
-    abs signum negate : A → A
-    fromℕ : ℕ → A
-open Num ⦃ … ⦄
-
-record NumCat (_→k_ : Set → Set → Set) (A : Set) : Set where
-  field
-    _+c_ _*c_ _-c_ : (A × A) →k A
-    negate-c : A →k A
-open NumCat ⦃ … ⦄
-
 instance
-  _ : ⦃ _ : Num A ⦄ → NumCat (λ (B C : Set) → B → C) A
-  _ = record
+  →-Num_ : ⦃ _ : Num A ⦄ → NumCat (λ (B C : Set) → B → C) A
+  →-Num_ = record
                    { _+c_ = uncurry _+_
                    ; _*c_ = uncurry _*_
                    ; _-c_ = uncurry _-_
@@ -214,15 +154,6 @@ evalStackOp (prim p) = first (evalPrim p)
 evalStackOp push = rassoc
 evalStackOp pop = lassoc
 
-instance
-  _ : Category (IxList _→k_)
-  _ = record {
-    idc = [] ;
-    _∘c_ = _∘il_ ;
-    id-l = refl ;
-    id-r = refl ;
-    assoc = refl }
-
 StackOps : Set → Set → Set
 StackOps = IxList StackOp
 
@@ -234,8 +165,8 @@ record StackProg (A : Set) (B : Set) : Set where
   field unSP : ∀ {Z : Set} → StackOps (A × Z) (B × Z)
 
 instance
-  _ : Category StackProg
-  _ = record {
+  StackProg-Category : Category StackProg
+  StackProg-Category = record {
     idc = sp idc ;
     _∘c_ = λ { (sp g) (sp f) → sp (g ∘c f) } ;
     id-l = refl ;
@@ -258,8 +189,8 @@ primSP : Prim A B → StackProg A B
 primSP p = sp [ prim p ]
 
 instance
-  _ : BraidedCat StackProg
-  _ = record { swap = primSP ‵swap }
+  StackProg-BraidedCat : BraidedCat StackProg
+  StackProg-BraidedCat = record { swap = primSP ‵swap }
 
 firstSP : StackProg A C → StackProg (A × B) (C × B)
 firstSP (sp ops) = sp ([ pop ] ∘c ops ∘c [ push ])
@@ -271,8 +202,8 @@ _×sp_ : StackProg A C → StackProg B D → StackProg (A × B) (C × D)
 f ×sp g = secondSP g ∘c firstSP f
 
 instance
-  _ : MonoidalP StackProg
-  _ = record { _×c_ = _×sp_ }
+  StackProg-MonoidalP : MonoidalP StackProg
+  StackProg-MonoidalP = record { _×c_ = _×sp_ }
 
 progFun-first : ∀ {f : StackProg A C}
               → progFun (firstSP {B = B} f) ≡ firstSF (progFun f)

--- a/Stack.agda
+++ b/Stack.agda
@@ -7,11 +7,8 @@ open import Data.Unit
 open import Function
 open import Data.Nat renaming (_+_ to _+ℕ_; _*_ to _*ℕ_)
 
-open import Relation.Binary.PropositionalEquality as PE
-       hiding (Extensionality; [_])
+open import Relation.Binary.PropositionalEquality as PE hiding ([_])
 open PE.≡-Reasoning
-open import Axiom.Extensionality.Propositional
-       using (Extensionality; ExtensionalityImplicit)
 open import Agda.Builtin.Equality.Rewrite
 
 open import IxList
@@ -20,10 +17,6 @@ private
   variable
    A B C D U V Z : Set
    _→k_ : Set → Set → Set
-
-postulate
-  .ext : ∀ {α β} → Extensionality α β
-  .ext-i : ∀ {α β} → ExtensionalityImplicit α β
 
 First : Set → Set → Set
 First A B = ∀ {Z : Set} → A × Z → B × Z

--- a/Stack.agda
+++ b/Stack.agda
@@ -2,6 +2,8 @@
 
 -- {-# OPTIONS --injective-type-constructors #-}
 
+module Stack where
+
 open import Data.Product renaming (swap to pswap)
 open import Data.Unit
 open import Function
@@ -11,6 +13,7 @@ open import Relation.Binary.PropositionalEquality as PE hiding ([_])
 open PE.≡-Reasoning
 open import Agda.Builtin.Equality.Rewrite
 
+open import Classes
 open import IxList
 
 private

--- a/Stack.agda
+++ b/Stack.agda
@@ -6,7 +6,7 @@ module Stack where
 
 open import Data.Product renaming (swap to pswap)
 open import Data.Unit
-open import Function
+open import Function hiding (id; _∘_)
 open import Data.Nat renaming (_+_ to _+ℕ_; _*_ to _*ℕ_)
 
 open import Relation.Binary.PropositionalEquality as PE hiding ([_])
@@ -59,19 +59,19 @@ sf g ∘sf sf f = sf (g ∘ f)
 instance
   StackFun-Category : Category StackFun
   StackFun-Category = record {
-    idc = id-sf ;
-    _∘c_ = _∘sf_ ;
+    id = id-sf ;
+    _∘_ = _∘sf_ ;
     id-l = refl ;
     id-r = refl ;
     assoc = refl }
 
 -- Homomorphisms
 
-.stackFun-id : stackFun {A} idc ≡ idc
+.stackFun-id : stackFun {A} id ≡ id
 stackFun-id = refl
 
 .stackFun-∘ : ∀ {g : B → C} {f : A → B}
-            → stackFun (g ∘c f) ≡ stackFun g ∘c stackFun f
+            → stackFun (g ∘ f) ≡ stackFun g ∘ stackFun f
 stackFun-∘ = refl
 
 instance
@@ -92,10 +92,10 @@ firstSF (sf f) = sf (lassoc ∘ f ∘ rassoc)
 stackFun-first = refl
 
 secondSF : StackFun B D → StackFun (A × B) (A × D)
-secondSF g = swap ∘c firstSF g ∘c swap
+secondSF g = swap ∘ firstSF g ∘ swap
 
 _×sf_ : StackFun A C → StackFun B D → StackFun (A × B) (C × D)
-f ×sf g = secondSF g ∘c firstSF f
+f ×sf g = secondSF g ∘ firstSF f
 
 -- -- Synthesized but not what we want
 -- sf f ×sf sf g = sf (λ { ((a , b) , z) → f (a , proj₁ (g (b , z))) , z })
@@ -167,8 +167,8 @@ record StackProg (A : Set) (B : Set) : Set where
 instance
   StackProg-Category : Category StackProg
   StackProg-Category = record {
-    idc = sp idc ;
-    _∘c_ = λ { (sp g) (sp f) → sp (g ∘c f) } ;
+    id = sp id ;
+    _∘_ = λ { (sp g) (sp f) → sp (g ∘ f) } ;
     id-l = refl ;
     id-r = refl ;
     assoc = refl }
@@ -176,11 +176,11 @@ instance
 progFun : StackProg A B → StackFun A B
 progFun (sp ops) = sf (evalStackOps ops)
 
-.progFun-id : progFun (idc {A = A}) ≡ idc
+.progFun-id : progFun (id {A = A}) ≡ id
 progFun-id = refl
 
 .progFun-∘ : ∀ {g : StackProg B C} {f : StackProg A B}
-           → progFun (g ∘c f) ≡ progFun g ∘c progFun f
+           → progFun (g ∘ f) ≡ progFun g ∘ progFun f
 progFun-∘ = refl
 
 -- The evalIL REWRITE pragmas make progFun-id and progFun-∘ proofs trivial.
@@ -193,13 +193,13 @@ instance
   StackProg-BraidedCat = record { swap = primSP ‵swap }
 
 firstSP : StackProg A C → StackProg (A × B) (C × B)
-firstSP (sp ops) = sp ([ pop ] ∘c ops ∘c [ push ])
+firstSP (sp ops) = sp ([ pop ] ∘ ops ∘ [ push ])
 
 secondSP : StackProg B D → StackProg (A × B) (A × D)
-secondSP g = swap ∘c firstSP g ∘c swap
+secondSP g = swap ∘ firstSP g ∘ swap
 
 _×sp_ : StackProg A C → StackProg B D → StackProg (A × B) (C × D)
-f ×sp g = secondSP g ∘c firstSP f
+f ×sp g = secondSP g ∘ firstSP f
 
 instance
   StackProg-MonoidalP : MonoidalP StackProg

--- a/Stack.agda
+++ b/Stack.agda
@@ -13,7 +13,7 @@ open import Relation.Binary.PropositionalEquality as PE hiding ([_])
 open PE.≡-Reasoning
 open import Agda.Builtin.Equality.Rewrite
 
-open import Classes
+open import Classes ⦃ … ⦄
 open import IxList
 
 private

--- a/Stack.agda
+++ b/Stack.agda
@@ -50,26 +50,6 @@ evalStackFun_stackFun₁ = refl
 evalStackFun_stackFun₂ : evalStackFun {A}{B} ∘ stackFun ≡ id
 evalStackFun_stackFun₂ = refl
 
-record Category (_→k_ : Set → Set → Set) : Set where
-  infixr 5 _∘c_
-  field
-    idc   : A →k A
-    _∘c_  : (B →k C) → (A →k B) → (A →k C)
-    .id-l  : ∀ {f : A →k B} → idc ∘c f ≡ f
-    .id-r  : ∀ {f : A →k B} → f ∘c idc ≡ f
-    .assoc : ∀ {h : C →k D} {g : B →k C} {f : A →k B}
-           → (h ∘c g) ∘c f ≡ h ∘c (g ∘c f)
-open Category ⦃ … ⦄
-
-instance
-  _ : Category (λ (A B : Set) → A → B)
-  _ = record {
-    idc = id ;
-    _∘c_ = _∘′_ ;
-    id-l = refl ;
-    id-r = refl ;
-    assoc = refl }
-
 id-sf : StackFun A A
 id-sf = sf id
 

--- a/Stack.agda
+++ b/Stack.agda
@@ -103,9 +103,9 @@ f ×sf g = secondSF g ∘ firstSF f
 instance
   StackFun-MonoidalP : MonoidalP StackFun
   StackFun-MonoidalP = record {
-    _×c_ = _×sf_ }
+    _⊗_ = _×sf_ }
 
-stackFun-× : ∀ {f : A → C} {g : B → D} → stackFun (f ×c g) ≡ stackFun f ×c stackFun g
+stackFun-× : ∀ {f : A → C} {g : B → D} → stackFun (f ⊗ g) ≡ stackFun f ⊗ stackFun g
 stackFun-× = refl
 
 instance
@@ -203,7 +203,7 @@ f ×sp g = secondSP g ∘ firstSP f
 
 instance
   StackProg-MonoidalP : MonoidalP StackProg
-  StackProg-MonoidalP = record { _×c_ = _×sp_ }
+  StackProg-MonoidalP = record { _⊗_ = _×sp_ }
 
 progFun-first : ∀ {f : StackProg A C}
               → progFun (firstSP {B = B} f) ≡ firstSF (progFun f)
@@ -214,5 +214,5 @@ progFun-second : ∀ {g : StackProg B D}
 progFun-second = refl
 
 progFun-× : ∀ {f : StackProg A C} {g : StackProg B D}
-          → progFun (f ×c g) ≡ progFun f ×c progFun g
+          → progFun (f ⊗ g) ≡ progFun f ⊗ progFun g
 progFun-× = refl


### PR DESCRIPTION
I’m looking for comments rather than a merge here.

I started factoring out `Category` and other type classes to a “`Classes`” module. I guess there’s something about modules and/or instances in Agda that I don’t understand. I’m getting an error:

    /Users/conal/Agda/Stack/Stack.agda:70,29-32
    (StackFun _A_147 _A_147) !=< (A → _B_144) of type Set
    when checking that the expression idc has type A → _B_144

What am I doing wrong here?
